### PR TITLE
switch to relative imports

### DIFF
--- a/custom_components/tankerkoenig/binary_sensor.py
+++ b/custom_components/tankerkoenig/binary_sensor.py
@@ -7,7 +7,7 @@ https://github.com/panbachi/homeassistant-tankerkoenig
 import logging
 from datetime import timedelta
 
-from custom_components.tankerkoenig import TankerkoenigDevice, CONF_STATIONS
+from . import TankerkoenigDevice, CONF_STATIONS
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.const import CONF_NAME
 from homeassistant.util import slugify

--- a/custom_components/tankerkoenig/sensor.py
+++ b/custom_components/tankerkoenig/sensor.py
@@ -7,7 +7,7 @@ https://github.com/panbachi/homeassistant-tankerkoenig
 import logging
 from datetime import timedelta
 
-from custom_components.tankerkoenig import TankerkoenigDevice, CONF_STATIONS
+from . import TankerkoenigDevice, CONF_STATIONS
 from homeassistant.const import CONF_MONITORED_CONDITIONS
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
simple change as suggested in https://developers.home-assistant.io/blog/2019/02/19/the-great-migration.html

> Do your users a favor and stick to relative imports to avoid having your component break during an upgrade. Example of a relative import is from . import DATA_BRIDGE.